### PR TITLE
Updated Migrator to use correct timestamps

### DIFF
--- a/src/Support/Database/Migrator.php
+++ b/src/Support/Database/Migrator.php
@@ -26,7 +26,7 @@ use Illuminate\Database\DatabaseManager;
 class Migrator
 {
 	private $manager;
-	
+
 	private $connection;
 
 	public function __construct(DatabaseManager $manager, $connection)
@@ -58,8 +58,7 @@ class Migrator
 			$table->boolean('wants_json');
 			$table->bigInteger('error_id')->unsigned()->nullable()->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_paths', function($table)
@@ -68,8 +67,7 @@ class Migrator
 
 			$table->string('path')->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_queries', function($table)
@@ -78,8 +76,7 @@ class Migrator
 
 			$table->string('query')->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_query_arguments', function($table)
@@ -90,8 +87,7 @@ class Migrator
 			$table->string('argument')->index();
 			$table->string('value')->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_routes', function($table)
@@ -101,8 +97,7 @@ class Migrator
 			$table->string('name')->index();
 			$table->string('action')->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_route_paths', function($table)
@@ -112,8 +107,7 @@ class Migrator
 			$table->string('route_id')->index();
 			$table->string('path')->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_route_path_parameters', function($table)
@@ -124,8 +118,7 @@ class Migrator
 			$table->string('parameter')->index();
 			$table->string('value')->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_agents', function($table)
@@ -136,8 +129,7 @@ class Migrator
 			$table->string('browser')->index();
 			$table->string('browser_version');
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_cookies', function($table)
@@ -146,8 +138,7 @@ class Migrator
 
 			$table->string('uuid')->unique();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_devices', function($table)
@@ -162,8 +153,7 @@ class Migrator
 
 			$table->unique(['kind', 'model', 'platform', 'platform_version']);
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_referers', function($table)
@@ -174,8 +164,7 @@ class Migrator
 			$table->string('url')->index();
 			$table->string('host');
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_domains', function($table)
@@ -184,8 +173,7 @@ class Migrator
 
 			$table->string('name')->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_sessions', function($table)
@@ -202,8 +190,7 @@ class Migrator
 			$table->bigInteger('geoip_id')->unsigned()->nullable()->index();
 			$table->boolean('is_robot');
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_errors', function($table)
@@ -213,8 +200,7 @@ class Migrator
 			$table->string('code')->index();
 			$table->string('message')->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_geoip', function($table)
@@ -235,8 +221,7 @@ class Migrator
 			$table->float('metro_code')->nullable();
 			$table->string('continent_code', 2)->nullable();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_sql_queries', function($table)
@@ -248,8 +233,7 @@ class Migrator
 			$table->float('time')->index();
 			$table->integer('connection_id')->unsigned();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_sql_query_bindings', function($table)
@@ -259,8 +243,7 @@ class Migrator
 			$table->string('sha1', 40)->index();
 			$table->text('serialized');
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_sql_query_bindings_parameters', function($table)
@@ -271,8 +254,7 @@ class Migrator
 			$table->string('name')->nullable()->index();
 			$table->text('value')->nullable();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_sql_queries_log', function($table)
@@ -282,8 +264,7 @@ class Migrator
 			$table->bigInteger('log_id')->unsigned()->index();
 			$table->bigInteger('sql_query_id')->unsigned()->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_connections', function($table)
@@ -292,8 +273,7 @@ class Migrator
 
 			$table->string('name')->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_events', function($table)
@@ -302,8 +282,7 @@ class Migrator
 
 			$table->string('name')->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_events_log', function($table)
@@ -314,8 +293,7 @@ class Migrator
 			$table->bigInteger('class_id')->unsigned()->index();
 			$table->bigInteger('log_id')->unsigned()->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 
 		$this->getSchemaBuilder()->create('tracker_system_classes', function($table)
@@ -324,8 +302,7 @@ class Migrator
 
 			$table->string('name')->index();
 
-			$this->timestamp('created_at')->index();
-			$this->timestamp('updated_at')->index();
+			$table->timestamps();
 		});
 	}
 
@@ -397,17 +374,17 @@ class Migrator
 	{
 		$this->getConnection()->beginTransaction();
 
-		try 
+		try
 		{
 			$this->{$method}();
-		} 
-		catch (\Exception $e) 
+		}
+		catch (\Exception $e)
 		{
 			$this->getConnection()->rollback();
 
 			if ($e instanceof \Illuminate\Database\QueryException)
 			{
-				throw new $e($e->getMessage(), $e->getBindings(), $e->previous);	
+				throw new $e($e->getMessage(), $e->getBindings(), $e->previous);
 			}
 			else
 			{


### PR DESCRIPTION
In response to https://github.com/antonioribeiro/tracker/issues/7
# 

I am getting

```
Call to undefined method PragmaRX\Tracker\Support\Database\Migrator::timestamp()
```

and I think it could be to do with the fact that you have

``` php
$this->timestamp('created_at')->index();
$this->timestamp('updated_at')->index();
```

everywhere instead of 

``` php
$table->timestamp('created_at')->index();
$table->timestamp('updated_at')->index();
```

Full ERROR:

```
Migration create_tracker_tables created successfully!
Generating optimized class loader
Running for workbench [fdw/core]...
Running for workbench [fdw/newsletter]...
Running for workbench [fdw/pages]...
Running for workbench [fdw/blog]...
Running for workbench [fdw/cart]...
PHP Fatal error:  Call to undefined method PragmaRX\Tracker\Support\Database\Migrator::timestamp() in /media/bravo/Development/website/bitbucket/website/vendor/pragmarx/tracker/src/Support/Database/Migrator.php on line 61
PHP Stack trace:
PHP   1. {main}() /media/bravo/Development/website/bitbucket/website/artisan:0
PHP   2. Symfony\Component\Console\Application->run() /media/bravo/Development/website/bitbucket/website/artisan:59
PHP   3. Symfony\Component\Console\Application->doRun() /media/bravo/Development/website/bitbucket/website/vendor/symfony/console/Symfony/Component/Console/Application.php:121
PHP   4. Symfony\Component\Console\Application->doRunCommand() /media/bravo/Development/website/bitbucket/website/vendor/symfony/console/Symfony/Component/Console/Application.php:191
PHP   5. Illuminate\Console\Command->run() /media/bravo/Development/website/bitbucket/website/vendor/symfony/console/Symfony/Component/Console/Application.php:885
PHP   6. Symfony\Component\Console\Command\Command->run() /media/bravo/Development/website/bitbucket/website/vendor/laravel/framework/src/Illuminate/Console/Command.php:96
PHP   7. Illuminate\Console\Command->execute() /media/bravo/Development/website/bitbucket/website/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:241
PHP   8. Fdw\Core\Console\SetupCommand->fire() /media/bravo/Development/website/bitbucket/website/vendor/laravel/framework/src/Illuminate/Console/Command.php:108
PHP   9. Fdw\Core\Console\SetupCommand->fireOtherPackages() /media/bravo/Development/website/bitbucket/website/workbench/fdw/core/src/Fdw/Core/Console/SetupCommand.php:34
PHP  10. Fdw\Core\Console\SetupCommand->fireTrackerPackage() /media/bravo/Development/website/bitbucket/website/workbench/fdw/core/src/Fdw/Core/Console/SetupCommand.php:80
PHP  11. Illuminate\Console\Command->call() /media/bravo/Development/website/bitbucket/website/workbench/fdw/core/src/Fdw/Core/Console/SetupCommand.php:91
PHP  12. Illuminate\Console\Command->run() /media/bravo/Development/website/bitbucket/website/vendor/laravel/framework/src/Illuminate/Console/Command.php:124
PHP  13. Symfony\Component\Console\Command\Command->run() /media/bravo/Development/website/bitbucket/website/vendor/laravel/framework/src/Illuminate/Console/Command.php:96
PHP  14. Illuminate\Console\Command->execute() /media/bravo/Development/website/bitbucket/website/vendor/symfony/console/Symfony/Component/Console/Command/Command.php:241
PHP  15. Illuminate\Database\Console\Migrations\MigrateCommand->fire() /media/bravo/Development/website/bitbucket/website/vendor/laravel/framework/src/Illuminate/Console/Command.php:108
PHP  16. Illuminate\Database\Migrations\Migrator->run() /media/bravo/Development/website/bitbucket/website/vendor/laravel/framework/src/Illuminate/Database/Console/Migrations/MigrateCommand.php:65
PHP  17. Illuminate\Database\Migrations\Migrator->runMigrationList() /media/bravo/Development/website/bitbucket/website/vendor/laravel/framework/src/Illuminate/Database/Migrations/Migrator.php:80
PHP  18. Illuminate\Database\Migrations\Migrator->runUp() /media/bravo/Development/website/bitbucket/website/vendor/laravel/framework/src/Illuminate/Database/Migrations/Migrator.php:109
PHP  19. CreateTrackerTables->up() /media/bravo/Development/website/bitbucket/website/vendor/laravel/framework/src/Illuminate/Database/Migrations/Migrator.php:133
PHP  20. PragmaRX\Tracker\Support\Database\Migrator->up() /media/bravo/Development/website/bitbucket/website/app/database/migrations/2014_06_11_040853_create_tracker_tables.php:16
PHP  21. PragmaRX\Tracker\Support\Database\Migrator->execute() /media/bravo/Development/website/bitbucket/website/vendor/pragmarx/tracker/src/Support/Database/Migrator.php:41
PHP  22. PragmaRX\Tracker\Support\Database\Migrator->createTables() /media/bravo/Development/website/bitbucket/website/vendor/pragmarx/tracker/src/Support/Database/Migrator.php:402
PHP  23. Illuminate\Database\Schema\Builder->create() /media/bravo/Development/website/bitbucket/website/vendor/pragmarx/tracker/src/Support/Database/Migrator.php:63
PHP  24. PragmaRX\Tracker\Support\Database\Migrator->PragmaRX\Tracker\Support\Database\{closure}() /media/bravo/Development/website/bitbucket/website/vendor/laravel/framework/src/Illuminate/Database/Schema/Builder.php:110
{"error":{"type":"Symfony\\Component\\Debug\\Exception\\FatalErrorException","message":"Call to undefined method PragmaRX\\Tracker\\Support\\Database\\Migrator::timestamp()","file":"\/media\/bravo\/Development\/website\/bitbucket\/website\/vendor\/pragmarx\/tracker\/src\/Support\/Database\/Migrator.php","line":61}}
```
