### PR TITLE
Fixed the domain creation code for domains without an extension

### DIFF
--- a/src/Data/RepositoryManager.php
+++ b/src/Data/RepositoryManager.php
@@ -351,12 +351,17 @@ class RepositoryManager implements RepositoryManagerInterface {
 	public function getRefererId($referer)
 	{
 		if ($referer)
-		{
+		{			
 			$url = parse_url($referer);
 
 			$parts = explode(".", $url['host']);
 
-			$domain_id = $this->getDomainId($parts[count($parts)-2] . "." . $parts[count($parts)-1]);
+			$domain = array_pop($parts);
+			if(sizeof($parts) > 0){
+				$domain = array_pop($parts) . "." . $domain;
+			}
+			
+			$domain_id = $this->getDomainId($domain);
 
 			return $this->refererRepository->findOrCreate(
 				array(


### PR DESCRIPTION
For local development i'm using a lot of domains without extension. This fixes a bug that is caused when you have a domain without an extension.
