### PR TITLE
travis: PHP 7.0 nightly added, few more improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - 7.0
   - hhvm
 
 before_script:
-  - travis_retry composer self-update
-  - travis_retry composer install --no-interaction --prefer-source --dev
+  - travis_retry composer install --no-interaction --prefer-source
 
 script:
-  -vendor/bin/phpunit --verbose
+  - phpunit --verbose


### PR DESCRIPTION
- `composer self-update` dropped
- `--dev` is on by default for couple of months
- use travis' phpunit, when it's available already