### PR TITLE
Update Event.php

### DIFF
--- a/src/Vendor/Laravel/Models/Event.php
+++ b/src/Vendor/Laravel/Models/Event.php
@@ -17,7 +17,7 @@ class Event extends Base {
 				->select(
 					'tracker_events.id',
 					'tracker_events.name',
-					$this->getConnection()->raw('count(tracker_events_log.id) as total')
+					$this->getConnection()->raw('count('.$this->getConnection()->getTablePrefix().'tracker_events_log.id) as total')
 				)
 				->from('tracker_events')
 				->period($minutes, 'tracker_events_log')


### PR DESCRIPTION
When working with multiple table prefixes and doing "raw" db operations "Datatables" requires the explicit tablePrefix.

NB: There might be other occurrences and/or better ways to deal with that but this fixed it for me.