### PR TITLE
Feature - custom trackVisit can also log tracker_route_path_parameters

### DIFF
--- a/src/Data/RepositoryManager.php
+++ b/src/Data/RepositoryManager.php
@@ -521,6 +521,8 @@ class RepositoryManager implements RepositoryManagerInterface
                 if ($route_path_id && $parameter && $value) {
                     $this->createRoutePathParameter($route_path_id, $parameter, $value);
                 }
+            } else if ($created && $route_path_id && $request["parameter"] && $request["value"]) {
+                $this->createRoutePathParameter($route_path_id, $request["parameter"], $request['value']);
             }
         }
 

--- a/src/Tracker.php
+++ b/src/Tracker.php
@@ -233,7 +233,8 @@ class Tracker
         $this->parserIsAvailable() &&
         $this->isTrackableIp() &&
         $this->isTrackableEnvironment() &&
-        $this->notRobotOrTrackable();
+        $this->notRobot() &&
+        $this->isTrackableRoute();
     }
 
     protected function isTrackableEnvironment() {
@@ -296,10 +297,24 @@ class Tracker
         }
     }
 
-    protected function notRobotOrTrackable() {
+    protected function notRobot() {
         return
             !$this->isRobot() ||
             !$this->config->get('do_not_track_robots');
+    }
+
+    protected function isTrackableRoute() {
+        if (is_null($this->route->currentRouteName())) {
+            return false;
+        }
+
+        $routes = $this->config->get('do_not_track_routes');
+
+        foreach ($routes as $route) {
+            $match = preg_grep ('/'. $route .'/i', [$this->route->currentRouteName()]);
+        }
+
+        return empty($match);
     }
 
     public function pageViews($minutes, $results = true) {

--- a/src/Tracker.php
+++ b/src/Tracker.php
@@ -61,7 +61,7 @@ class Tracker
     }
 
     public function checkCurrentUser() {
-        if ($this->isTrackable() && !$this->getSessionData()['user_id'] && $user_id = $this->getUserId()) {
+        if (!$this->getSessionData()['user_id'] && $user_id = $this->getUserId()) {
             return true;
         }
 
@@ -304,10 +304,6 @@ class Tracker
     }
 
     protected function isTrackableRoute() {
-        if (is_null($this->route->currentRouteName())) {
-            return false;
-        }
-
         $routes = $this->config->get('do_not_track_routes');
 
         foreach ($routes as $route) {

--- a/src/Tracker.php
+++ b/src/Tracker.php
@@ -61,7 +61,7 @@ class Tracker
     }
 
     public function checkCurrentUser() {
-        if (!$this->getSessionData()['user_id'] && $user_id = $this->getUserId()) {
+        if ($this->isTrackable() && !$this->getSessionData()['user_id'] && $user_id = $this->getUserId()) {
             return true;
         }
 


### PR DESCRIPTION
```
        Tracker::trackVisit(
            [
                'name' => 'v1.blogs.show',
                'action' => 'BlogController@show',
            ],
            [
              'path' => 'v1/blogs/1001',
              'parameter' => 'blog_id',
              'value' => 1001
            ]
        );
```