### PR TITLE
allow track visit to log tracker_route_path_parameters

### DIFF
--- a/src/Data/RepositoryManager.php
+++ b/src/Data/RepositoryManager.php
@@ -521,6 +521,8 @@ class RepositoryManager implements RepositoryManagerInterface
                 if ($route_path_id && $parameter && $value) {
                     $this->createRoutePathParameter($route_path_id, $parameter, $value);
                 }
+            } else if ($created && $route_path_id && $request["parameter"] && $request["value"]) {
+                $this->createRoutePathParameter($route_path_id, $request["parameter"], $request['value']);
             }
         }
 


### PR DESCRIPTION
```
        Tracker::trackVisit(
            [
                'name' => 'v1.blogs.show',
                'action' => 'BlogController@show',
            ],
            [
              'path' => 'v1/blogs/1001',
              'parameter' => 'blog_id',
              'value' => 1001
            ]
        );
```

```
[vagrant@zapstore vagrant]$ mysql -uroot -ptracker tracker -e "select * from tracker_route_path_parameters"
+----+---------------+------------+-------+---------------------+-------------------+
| id | route_path_id | parameter  | value | created_at          | updated_at        |
+----+---------------+------------+-------+---------------------+-------------------+
|  4 |             9 | blog_id | 3     | 2016-02-15 19:08:32 | 2016-02-15 19:08:32 |
|  5 |            10 | blog_id | 1     | 2016-02-16 11:29:11 | 2016-02-16 11:29:11 |
|  6 |            11 | blog_id | 1     | 2016-02-16 11:34:29 | 2016-02-16 11:34:29 |
|  7 |            12 | blog_id | 2     | 2016-02-16 11:34:32 | 2016-02-16 11:34:32 |
|  8 |            13 | blog_id | 1     | 2016-02-16 11:47:21 | 2016-02-16 11:47:21 |
|  9 |            14 | blog_id | 100   | 2016-02-16 12:01:36 | 2016-02-16 12:01:36 |
| 10 |            15 | blog_id | 10    | 2016-02-16 12:01:40 | 2016-02-16 12:01:40 |
| 18 |            20 | blog_id | 1000  | 2016-02-16 15:19:03 | 2016-02-16 15:19:03 |⇦⇦⇦⇦
| 19 |            21 | blog_id | 1001  | 2016-02-16 16:24:09 | 2016-02-16 16:24:09 |⇦⇦⇦⇦
+----+---------------+------------+-------+---------------------+-------------------+
```