### PR TITLE
Replaced call to undefined Illuminate\Routing\Route::getUri() by uri()

### DIFF
--- a/src/Data/RepositoryManager.php
+++ b/src/Data/RepositoryManager.php
@@ -565,7 +565,7 @@ class RepositoryManager implements RepositoryManagerInterface
             return $name;
         }
 
-        return '/'.$route->current()->getUri();
+        return '/'.$route->current()->uri();
     }
 
     /**


### PR DESCRIPTION
Fixes the following error:

> Symfony\Component\Debug\Exception\FatalThrowableError: Call to undefined method Illuminate\Routing\Route::getUri() 
> in /home/forge/ilini.com/vendor/pragmarx/tracker/src/Data/RepositoryManager.php:564