### PR TITLE
Display only the exception message.

### DIFF
--- a/src/migrations/2017_01_31_311101_fix_agent_name.php
+++ b/src/migrations/2017_01_31_311101_fix_agent_name.php
@@ -33,7 +33,7 @@ class FixAgentName extends Migration
                 }
             );
         } catch (\Exception $e) {
-            dd($e);
+            dd($e->getMessage());
         }
     }
 


### PR DESCRIPTION
On the migration file, displaying only the error message is more sensible.

On a fresh install of the package on a fresh Laravel 5 app, running $ `php artisan migrate` is bombarded by a very long `dd()` output of the error. Without editing the file actual migration file to only display the message of the error, nobody would be able to identify the problem.

You can replicate the error on a fresh install of the package on an existing or fresh Laravel 5 app.