### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -118,11 +118,11 @@
 - HTTP cache by removing PHP session_start
 
 ## [0.5.1] - 2014-07-03
-###Added
+### Added
 - A 'Today' filter option on Stats Panel
 - All stats tables are now Google Charts Tables (paginated)
 
 ## [0.5.0] - 2014-07-02
-###Changed
+### Changed
 - Moved pie charts from flot to Google Charts
  

--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 
 [![Latest Stable Version](https://img.shields.io/packagist/v/pragmarx/tracker.svg?style=flat-square)](https://packagist.org/packages/pragmarx/tracker) [![License](https://img.shields.io/badge/license-BSD_3_Clause-brightgreen.svg?style=flat-square)](LICENSE) [![Downloads](https://img.shields.io/packagist/dt/pragmarx/tracker.svg?style=flat-square)](https://packagist.org/packages/pragmarx/tracker)
 
-###Tracker gathers a lot of information from your requests to identify and store:
+### Tracker gathers a lot of information from your requests to identify and store:
 
 - **Sessions**
 - **Page Views (hits on routes)**
@@ -21,7 +21,7 @@
 - **Url queries and all its arguments**
 - **Database connections**
 
-##Index
+## Index
 
 - [Why?](#why)
 - [How To Use It](#usage)
@@ -465,14 +465,14 @@ All tables are prefixed by `tracker_`, and here's an extract of some of them, sh
 
 If your application has special needs, you can manually log things like:
 
-####Events  
+#### Events  
 
 ```
 Tracker::trackEvent(['event' => 'cart.add']);
 Tracker::trackEvent(['event' => 'cart.add', 'object' => 'App\Cart\Events\Add']);
 ```
 
-####Routes
+#### Routes
 
 ```
 Tracker::trackVisit(
@@ -495,19 +495,19 @@ For Laravel 4+ please use version 2.0.10.
 
 ## Installing
 
-####Require the `tracker` package by **executing** the following command in your command line:
+#### Require the `tracker` package by **executing** the following command in your command line:
 
     composer require pragmarx/tracker
 
-####Add the service provider to your app/config/app.php:
+#### Add the service provider to your app/config/app.php:
 
     'PragmaRX\Tracker\Vendor\Laravel\ServiceProvider',
 
-####Add the alias to the facade on your app/config/app.php:
+#### Add the alias to the facade on your app/config/app.php:
 
     'Tracker' => 'PragmaRX\Tracker\Vendor\Laravel\Facade',
 
-####Publish tracker configuration:
+#### Publish tracker configuration:
 
 **Laravel 4**
 
@@ -517,27 +517,27 @@ For Laravel 4+ please use version 2.0.10.
 
     php artisan vendor:publish
 
-####Enable the Middleware (Laravel 5)
+#### Enable the Middleware (Laravel 5)
 
     'use_middleware' => true,
 
-####Add the Middleware to Laravel Kernel (Laravel 5)
+#### Add the Middleware to Laravel Kernel (Laravel 5)
 
 Open the file `app/Http/Kernel.php` and add the following to your web middlewares:
 
     \PragmaRX\Tracker\Vendor\Laravel\Middlewares\Tracker::class,
 
-####Enable Tracker in your config.php (Laravel 4) or tracker.php (Laravel 5)
+#### Enable Tracker in your config.php (Laravel 4) or tracker.php (Laravel 5)
 
     'enabled' => true,
 
-####Publish the migration
+#### Publish the migration
 
     php artisan tracker:tables
 
 This is only needed if you are on Laravel 4, because `vendor:publish` does it for you in Laravel 5.
 
-####Create a database connection for it on your `config/database.php`
+#### Create a database connection for it on your `config/database.php`
 
 	'tracker' => [
 		'driver'   => '...',
@@ -546,7 +546,7 @@ This is only needed if you are on Laravel 4, because `vendor:publish` does it fo
 		...
 	],
 
-####Migrate it
+#### Migrate it
 
 If you have set the default connection to `tracker`, you can
 
@@ -556,7 +556,7 @@ Otherwise you'll have to
 
     php artisan migrate --database=tracker
 
-####If you are planning to store Geo IP information, also install the geoip package:
+#### If you are planning to store Geo IP information, also install the geoip package:
 
     composer require "geoip/geoip":"~1.14"
 
@@ -564,7 +564,7 @@ Otherwise you'll have to
 
     composer require "geoip2/geoip2":"~2.0"
 
-####And make sure you don't have the PHP module installed. This is a Debian/Ubuntu example:
+#### And make sure you don't have the PHP module installed. This is a Debian/Ubuntu example:
 
 	sudo apt-get purge php5-geoip
 

--- a/upgrading.md
+++ b/upgrading.md
@@ -11,15 +11,15 @@ Add cache_enabled key to your config\tracker.php:
 
 ## from 2.0.x to 2.0.4 or 2.0.9 
 
-####Run Artisan tracker:tables command
+#### Run Artisan tracker:tables command
 
     php artisan tracker:tables
 
-####Migrate
+#### Migrate
 
     php artisan migrate
 
-####If you already have executed and get the error "1215 Cannot add foreign key constraint"
+#### If you already have executed and get the error "1215 Cannot add foreign key constraint"
 
 You'll have to upgrade your migrations:
 
@@ -48,20 +48,20 @@ A [massive update happened at StartBootstrap](https://github.com/IronSummitMedia
 
 ## to 0.5.1
 
-####As `tracker_route_paths.route_id` column was wrongly set to string, you need to change it to int8 or bigint. This is how you do this
+#### As `tracker_route_paths.route_id` column was wrongly set to string, you need to change it to int8 or bigint. This is how you do this
  
-#####In PostgreSQL 
+##### In PostgreSQL 
 ```
 ALTER TABLE "tracker_route_paths" ALTER COLUMN route_id TYPE BIGINT 
     USING CAST(CASE route_id WHEN '' THEN NULL ELSE route_id END AS BIGINT)
 ```
 
-#####In MySQL
+##### In MySQL
 ```
 ALTER TABLE tracker_route_paths CHANGE route_id route_id bigint unsigned NULL;
 ```
 
-####Add the following keys to your `app/config/packages/pragmarx/tracker/config.php`:
+#### Add the following keys to your `app/config/packages/pragmarx/tracker/config.php`:
 
 ```
 'log_exceptions' => true,
@@ -75,14 +75,14 @@ ALTER TABLE tracker_route_paths CHANGE route_id route_id bigint unsigned NULL;
    
 ## to 0.5.0
 
-####Download sb-panel v2, if you want to access the new Stats Panel:
+#### Download sb-panel v2, if you want to access the new Stats Panel:
 
 ```
 wget --output-document=/tmp/sba2.zip http://startbootstrap.com/downloads/sb-admin-v2.zip
 unzip /tmp/sba2.zip -d public/templates/
 ```
 
-####Add the following keys to your `app/config/packages/pragmarx/tracker/config.php`:
+#### Add the following keys to your `app/config/packages/pragmarx/tracker/config.php`:
 
 ```
 /**
@@ -123,7 +123,7 @@ unzip /tmp/sba2.zip -d public/templates/
 'stats_controllers_namespace' => 'PragmaRX\Tracker\Vendor\Laravel\Controllers',
 ```
 
-####The Stats Panel must be enabled in your config file
+#### The Stats Panel must be enabled in your config file
 
 ```
 'stats_panel_enabled' => true,
@@ -131,7 +131,7 @@ unzip /tmp/sba2.zip -d public/templates/
 
 ## to 0.4.0
 
-####Add the following keys to your `app/config/packages/pragmarx/tracker/config.php`:
+#### Add the following keys to your `app/config/packages/pragmarx/tracker/config.php`:
 
 ```
 'log_geoip' => true,
@@ -144,8 +144,8 @@ unzip /tmp/sba2.zip -d public/templates/
 'log_routes' => true,
 ```
 
-####On `tracker_sessions` table, alter columns `device_id` and `agent_id` to be nullable.
-####On `tracker_log` table, alter column `path_id` to be nullable.
+#### On `tracker_sessions` table, alter columns `device_id` and `agent_id` to be nullable.
+#### On `tracker_log` table, alter column `path_id` to be nullable.
 
 ## to 0.3.2
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
