### PR TITLE
Hash the user agent.

### DIFF
--- a/src/Data/RepositoryManager.php
+++ b/src/Data/RepositoryManager.php
@@ -351,6 +351,9 @@ class RepositoryManager implements RepositoryManagerInterface
             'name' => $this->getCurrentUserAgent()
                 ?: 'Other',
 
+            'hash' => hash('sha256', $this->getCurrentUserAgent()
+                ?: 'Other'),
+
             'browser' => $this->userAgentParser->userAgent->family,
 
             'browser_version' => $this->userAgentParser->getUserAgentVersion(),

--- a/src/Vendor/Laravel/Models/Agent.php
+++ b/src/Vendor/Laravel/Models/Agent.php
@@ -7,6 +7,7 @@ class Agent extends Base
     protected $table = 'tracker_agents';
 
     protected $fillable = ['name',
+    							'hash',
                                 'browser',
                                 'browser_version', ];
 }

--- a/src/migrations/2017_01_31_311101_fix_agent_name.php
+++ b/src/migrations/2017_01_31_311101_fix_agent_name.php
@@ -29,7 +29,8 @@ class FixAgentName extends Migration
             $this->builder->table(
                 $this->table,
                 function ($table) {
-                    $table->mediumText('name')->unique()->change();
+                    $table->mediumText('name')->change();
+                    $table->string('hash')->after('name')->unique();
                 }
             );
         } catch (\Exception $e) {
@@ -50,9 +51,12 @@ class FixAgentName extends Migration
                 function ($table) {
                     $table->string('name', 255)->change();
                     $table->unique('name');
+                    $table->dropUnique('tracker_agents_hash_unique');
+                    $table->dropColumn('hash');
                 }
             );
         } catch (\Exception $e) {
+            dd($e->getMessage());
         }
     }
 }


### PR DESCRIPTION
To resolve issue [https://github.com/antonioribeiro/tracker/issues/279](https://github.com/antonioribeiro/tracker/issues/279), this commit implements the hashing of the user agent.

Briefly, this commit did the following:

- Keep the name attribute as MEDIUM TEXT to allow us to store user agents that are reasonably long;
- Do not add a unique index to the name attribute because its a TEXT, and that MySQL doesn't like adding indexes to texts.
- Added unique `hash` column for the `tracker_agents` table;
- Include the hash (SHA-256) of the user agent name when logging user agents;

For the necessary updates, let me know here.