### PR TITLE
Disable booting tracker from service provider

### DIFF
--- a/src/Vendor/Laravel/ServiceProvider.php
+++ b/src/Vendor/Laravel/ServiceProvider.php
@@ -74,7 +74,7 @@ class ServiceProvider extends PragmaRXServiceProvider
 
             $this->registerErrorHandler();
 
-            $this->bootTracker();
+            //$this->bootTracker();
 
             $this->loadTranslations();
         }


### PR DESCRIPTION
The app request cycle loads the service provider before the middleware , So if a guest logs in he won't be recognized as that user because the service provider boots the tracker along side the middleware too, also this causes two page views instead of one (because tracker is booted twice , one from the service provider and the other from the middle ware);