### PR TITLE
Update 2015_03_07_311076_create_tracker_agents_table.php

### DIFF
--- a/src/migrations/2015_03_07_311076_create_tracker_agents_table.php
+++ b/src/migrations/2015_03_07_311076_create_tracker_agents_table.php
@@ -26,6 +26,7 @@ class CreateTrackerAgentsTable extends Migration
                 $table->string('name')->unique();
                 $table->string('browser')->index();
                 $table->string('browser_version');
+                $table->string('name_hash')->index();
 
                 $table->timestamp('created_at')->index();
                 $table->timestamp('updated_at')->index();


### PR DESCRIPTION
Fixes the error in Tracker_agent Migration. SQLSTATE[42S22]: Column not found: 1054 Unknown column 'name_hash'