### PR TITLE
Laravel 5.6 logger fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "ua-parser/uap-php" : "~3.4",
         "pragmarx/datatables": "1.4.11",
         "snowplow/referer-parser": "~0.1",
-        "jaybizzle/crawler-detect": "~1.0"
+        "jaybizzle/crawler-detect": "~1.0",
+        "psr/log": "~1.0"
     },
 
     "suggest": {

--- a/src/Tracker.php
+++ b/src/Tracker.php
@@ -4,7 +4,6 @@ namespace PragmaRX\Tracker;
 
 use Illuminate\Foundation\Application as Laravel;
 use Illuminate\Http\Request;
-use Illuminate\Log\Writer as Logger;
 use Illuminate\Routing\Router;
 use PragmaRX\Support\Config;
 use PragmaRX\Support\GeoIp\Updater as GeoIpUpdater;
@@ -12,6 +11,7 @@ use PragmaRX\Support\IpAddress;
 use PragmaRX\Tracker\Data\RepositoryManager as DataRepositoryManager;
 use PragmaRX\Tracker\Repositories\Message as MessageRepository;
 use PragmaRX\Tracker\Support\Minutes;
+use Psr\Log\LoggerInterface;
 
 class Tracker
 {
@@ -45,7 +45,7 @@ class Tracker
         DataRepositoryManager $dataRepositoryManager,
         Request $request,
         Router $route,
-        Logger $logger,
+        LoggerInterface $logger,
         Laravel $laravel,
         MessageRepository $messageRepository
     ) {


### PR DESCRIPTION
In Laravel 5.6, the Laravel Log interface and Writer class have been removed, replaced by the Illuminate\Log\LogManager class, which implements Psr\Log\LoggerInterface. This change breaks the tracker construction.

Prior to Laravel 5.6, Illuminate\Log\Writer implements Psr\Log\LoggerInterface, it must follow and change type declaration from Illuminate\Log\Writer to Psr\Log\LoggerInterface.