### PR TITLE
Fix migrations with default MySQL connection.

### DIFF
--- a/src/Support/Migration.php
+++ b/src/Support/Migration.php
@@ -10,7 +10,7 @@ abstract class Migration extends PragmaRxMigration
     {
         $this->manager = app()->make('db');
 
-        $this->connection = $this->manager->connection('tracker');
+        $this->connection = $this->manager->connection(config('tracker.connection'));
 
         parent::checkConnection();
     }


### PR DESCRIPTION
Previously you could not migrate all tables if you were using a connection other than 'tracker', commit changes migrations to use the connection set in the tracker config.