### PR TITLE
Remove unused variables

### DIFF
--- a/src/Vendor/Laravel/Controllers/Stats.php
+++ b/src/Vendor/Laravel/Controllers/Stats.php
@@ -79,10 +79,7 @@ class Stats extends Controller
 
     public function log($uuid)
     {
-        $session = Tracker::sessionLog($uuid);
-
         return View::make('pragmarx/tracker::log')
-                ->with('log', Tracker::sessionLog($uuid))
                 ->with('uuid', $uuid)
                 ->with('title', 'log');
     }


### PR DESCRIPTION
Just a bit of cleanup. `Tracker::sessionLog($uuid)` was called 2 times here. The variable 'log' passed to the view is also unused because it just makes an ajax request with the uuid.

Please note that this could be a breaking change if someone extended the log view and used the `$log` variable without extending the controller.