### PR TITLE
Fix for Laravel ^5.8

### DIFF
--- a/src/Support/Exceptions/Handler.php
+++ b/src/Support/Exceptions/Handler.php
@@ -69,6 +69,11 @@ class Handler implements ExceptionHandler
         $this->illuminateHandler->report($e);
     }
 
+    public function shouldReport(Exception $e)
+    {
+        return $this->illuminateHandler->shouldReport($e);
+    }
+
     public function render($request, Exception $e)
     {
         return $this->illuminateHandler->render($request, $e);

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -246,7 +246,12 @@ return [
 
     /*
      * ** IMPORTANT **
-     *   Change the user model to your own.
+     * Change the user model to your own.
+     * If the model is under a different connection, be specific.
+     * ...
+     * class ModelName {
+     *      protected $connection = 'mysql';
+     * ...
      */
     'user_model' => 'PragmaRX\Tracker\Vendor\Laravel\Models\User',
 


### PR DESCRIPTION
#435 #437 

- Adds a hint in the configuration file about the need to explicitly specify the connection in the user template.
- Adds the shouldReport method to the ExceptionHandler class to support the class interface contract in laravel +5.8.