### PR TITLE
fix laravel6

### DIFF
--- a/src/Vendor/Laravel/Controllers/Stats.php
+++ b/src/Vendor/Laravel/Controllers/Stats.php
@@ -7,6 +7,7 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\View;
 use PragmaRX\Tracker\Vendor\Laravel\Facade as Tracker;
 use PragmaRX\Tracker\Vendor\Laravel\Support\Session;
+use Illuminate\Support\Str;
 
 class Stats extends Controller
 {
@@ -332,7 +333,7 @@ class Stats extends Controller
         $user = $this->authentication->user();
 
         foreach ($this->adminProperties as $property) {
-            $propertyCamel = camel_case($property);
+            $propertyCamel = Str::camel($property);
 
             if (
                     isset($user->$property) ||
@@ -352,7 +353,7 @@ class Stats extends Controller
         $user = $this->authentication->user();
 
         foreach ($this->adminProperties as $property) {
-            $propertyCamel = camel_case($property);
+            $propertyCamel = Str::camel($property);
 
             if (
                 (isset($user->$property) && $user->$property) ||

--- a/src/Vendor/Laravel/Support/Session.php
+++ b/src/Vendor/Laravel/Support/Session.php
@@ -2,7 +2,7 @@
 
 namespace PragmaRX\Tracker\Vendor\Laravel\Support;
 
-use Illuminate\Support\Facades\Input;
+use Illuminate\Support\Facades\Request;
 use PragmaRX\Tracker\Support\Minutes;
 use Session as LaravelSession;
 
@@ -29,8 +29,8 @@ class Session
 
     public function getValue($variable, $default = null)
     {
-        if (Input::has($variable)) {
-            $value = Input::get($variable);
+        if (Request::has($variable)) {
+            $value = Request::get($variable);
         } else {
             $value = LaravelSession::get('tracker.stats.'.$variable, $default);
         }


### PR DESCRIPTION
Fix for laravel 6.*

"Error Class 'Illuminate\Support\Facades\Input' not found occured." Input no longer available in larave 6.*, replace with Request in src/Vendor/Laravel/Support/Session.php and vendor/pragmarx/datatables/src/Bllim/Datatables/Datatables.php

Undefined function "camel_case" replaced with Str::camel in /src/Vendor/Laravel/Controllers/Stats.php 