### PR TITLE
Issues 490 : Adding Default $userAgent

### DIFF
--- a/src/Support/UserAgentParser.php
+++ b/src/Support/UserAgentParser.php
@@ -18,6 +18,8 @@ class UserAgentParser
 
     public function __construct($basePath, $userAgent = null)
     {
+        $userAgent = $_SERVER['HTTP_USER_AGENT'];
+
         if (!$userAgent && isset($_SERVER['HTTP_USER_AGENT'])) {
             $userAgent = $_SERVER['HTTP_USER_AGENT'];
         }
@@ -37,15 +39,15 @@ class UserAgentParser
 
     public function getOperatingSystemVersion()
     {
-        return    $this->operatingSystem->major.
-                ($this->operatingSystem->minor !== null ? '.'.$this->operatingSystem->minor : '').
-                ($this->operatingSystem->patch !== null ? '.'.$this->operatingSystem->patch : '');
+        return $this->operatingSystem->major .
+            ($this->operatingSystem->minor !== null ? '.' . $this->operatingSystem->minor : '') .
+            ($this->operatingSystem->patch !== null ? '.' . $this->operatingSystem->patch : '');
     }
 
     public function getUserAgentVersion()
     {
-        return  $this->userAgent->major.
-                ($this->userAgent->minor !== null ? '.'.$this->userAgent->minor : '').
-                ($this->userAgent->patch !== null ? '.'.$this->userAgent->patch : '');
+        return $this->userAgent->major .
+            ($this->userAgent->minor !== null ? '.' . $this->userAgent->minor : '') .
+            ($this->userAgent->patch !== null ? '.' . $this->userAgent->patch : '');
     }
 }

--- a/src/Support/UserAgentParser.php
+++ b/src/Support/UserAgentParser.php
@@ -19,7 +19,6 @@ class UserAgentParser
     public function __construct($basePath, $userAgent = null)
     {
         $userAgent = $_SERVER['HTTP_USER_AGENT'];
-
         if (!$userAgent && isset($_SERVER['HTTP_USER_AGENT'])) {
             $userAgent = $_SERVER['HTTP_USER_AGENT'];
         }

--- a/src/Support/UserAgentParser.php
+++ b/src/Support/UserAgentParser.php
@@ -18,9 +18,10 @@ class UserAgentParser
 
     public function __construct($basePath, $userAgent = null)
     {
-        $userAgent = $_SERVER['HTTP_USER_AGENT'];
-        if (!$userAgent && isset($_SERVER['HTTP_USER_AGENT'])) {
-            $userAgent = $_SERVER['HTTP_USER_AGENT'];
+        $defaultUserAgent = 'Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0';
+
+        if (!$userAgent) {
+            $userAgent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : $defaultUserAgent;
         }
 
         $this->parser = Parser::create()->parse($userAgent);


### PR DESCRIPTION
In Parser.php line 35:
Argument 1 passed to UAParser\Parser::parse() must be of the type string, null given, called in D
:\Projects*****\vendor\pragmarx\tracker\src\Support\UserAgentParser.php on line 25

I added in method "__construct"
$userAgent = $_SERVER['HTTP_USER_AGENT'];



