### PR TITLE
Null User agent during artisan config:cache causes failure

### DIFF
--- a/src/Support/UserAgentParser.php
+++ b/src/Support/UserAgentParser.php
@@ -21,7 +21,9 @@ class UserAgentParser
         if (!$userAgent && isset($_SERVER['HTTP_USER_AGENT'])) {
             $userAgent = $_SERVER['HTTP_USER_AGENT'];
         }
-
+        
+        if(strlen($userAgent)===0) $userAgent = '';
+        
         $this->parser = Parser::create()->parse($userAgent);
 
         $this->userAgent = $this->parser->ua;


### PR DESCRIPTION
Added safety catch for null `$userAgent` as when executing `php artisan config:cache` a null `$userAgent` was causing the parser to fail and thus artisan would exit.