### PR TITLE
Commented Boot and Fixed user parser, fixes #479 #490

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pragmarx/tracker",
+    "name": "renderbit/tracker",
 
     "description": "A Laravel Visitor Tracker",
 
@@ -9,9 +9,9 @@
 
     "authors": [
         {
-            "name": "Antonio Carlos Ribeiro",
-            "email": "acr@antoniocarlosribeiro.com",
-            "role": "Creator & Designer"
+            "name": "Riju Pramanik",
+            "email": "riju@renderbit.com",
+            "role": "Forked from prgmarx/tracker "
         }
     ],
 

--- a/src/Support/UserAgentParser.php
+++ b/src/Support/UserAgentParser.php
@@ -16,8 +16,9 @@ class UserAgentParser
 
     public $originalUserAgent;
 
-    public function __construct($basePath, $userAgent = null)
+   public function __construct($basePath, $userAgent = null)
     {
+        $userAgent = $_SERVER['HTTP_USER_AGENT'];
         if (!$userAgent && isset($_SERVER['HTTP_USER_AGENT'])) {
             $userAgent = $_SERVER['HTTP_USER_AGENT'];
         }

--- a/src/Vendor/Laravel/ServiceProvider.php
+++ b/src/Vendor/Laravel/ServiceProvider.php
@@ -81,7 +81,7 @@ class ServiceProvider extends PragmaRXServiceProvider
 
         $this->registerErrorHandler();
 
-        $this->bootTracker();
+        //$this->bootTracker();
 
         $this->loadTranslations();
     }


### PR DESCRIPTION
'log_users' flag doesn't work if this line is not commented, as discussed in #479 
Fixes constructor #490 