### PR TITLE
Change $userAgent parameter from null to empty string

### DIFF
--- a/src/Support/UserAgentParser.php
+++ b/src/Support/UserAgentParser.php
@@ -16,7 +16,7 @@ class UserAgentParser
 
     public $originalUserAgent;
 
-    public function __construct($basePath, $userAgent = null)
+    public function __construct($basePath, $userAgent = '')
     {
         if (!$userAgent && isset($_SERVER['HTTP_USER_AGENT'])) {
             $userAgent = $_SERVER['HTTP_USER_AGENT'];


### PR DESCRIPTION
For the error `Argument 1 passed to UAParser\Parser::parse() must be of the type string, null given`

I found the other 2 pull requests #493 and #500 a bit hacky and convoluted to fix this. My thinking here is that it doesn't make sense to have a `null` default value for the `$userAgent` parameter since the `parse()` function will never take it. So just changing it to an empty string will resolve this particular issue without affecting the `!$userAgent` condition which still resolves to `true` for an empty string.