### PR TITLE
guard bootTracker with use_middleware

### DIFF
--- a/src/Support/UserAgentParser.php
+++ b/src/Support/UserAgentParser.php
@@ -18,10 +18,11 @@ class UserAgentParser
 
     public function __construct($basePath, $userAgent = null)
     {
-        if (!$userAgent && isset($_SERVER['HTTP_USER_AGENT'])) {
-            $userAgent = $_SERVER['HTTP_USER_AGENT'];
+        $defaultUserAgent = 'Mozilla/5.0 (Windows NT 5.1; rv:31.0) Gecko/20100101 Firefox/31.0';
+        if (!$userAgent) {
+            $userAgent = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : $defaultUserAgent;
         }
-
+        
         $this->parser = Parser::create()->parse($userAgent);
 
         $this->userAgent = $this->parser->ua;

--- a/src/Vendor/Laravel/ServiceProvider.php
+++ b/src/Vendor/Laravel/ServiceProvider.php
@@ -81,7 +81,9 @@ class ServiceProvider extends PragmaRXServiceProvider
 
         $this->registerErrorHandler();
 
-        $this->bootTracker();
+        if (!$this->getConfig('use_middleware')) {
+            $this->bootTracker();
+        }
 
         $this->loadTranslations();
     }


### PR DESCRIPTION
This PR solve the missing user_id when tracking the session. In order to get the user_id, tracker need to be loaded/boot under middleware because session is not generated yet on ServiceProvider boot environment.
