### PR TITLE
guard bootTracker with use_middleware

### DIFF
--- a/src/Vendor/Laravel/ServiceProvider.php
+++ b/src/Vendor/Laravel/ServiceProvider.php
@@ -81,7 +81,9 @@ class ServiceProvider extends PragmaRXServiceProvider
 
         $this->registerErrorHandler();
 
-        $this->bootTracker();
+        if (!$this->getConfig('use_middleware')) {
+            $this->bootTracker();
+        }
 
         $this->loadTranslations();
     }


### PR DESCRIPTION
This PR solve the missing user_id when tracking the session. In order to get the user_id, tracker need to be loaded/boot under middleware because session is not generated yet on ServiceProvider boot environment.